### PR TITLE
Fix: pause -> resume 불가 버그 수정

### DIFF
--- a/src/main/java/org/example/game/logic/GameLogic.java
+++ b/src/main/java/org/example/game/logic/GameLogic.java
@@ -73,7 +73,7 @@ public class GameLogic {
     public boolean moveLeft() {
         if (gameOver || currentPiece == null) return false;
 
-        TetrominoPosition newPos = SRSRotationSystem.moveLeft(currentPiece, board);
+        TetrominoPosition newPos = SuperRotationSystem.moveLeft(currentPiece, board);
         if (newPos != null) {
             currentPiece = newPos;
             return true;
@@ -84,7 +84,7 @@ public class GameLogic {
     public boolean moveRight() {
         if (gameOver || currentPiece == null) return false;
 
-        TetrominoPosition newPos = SRSRotationSystem.moveRight(currentPiece, board);
+        TetrominoPosition newPos = SuperRotationSystem.moveRight(currentPiece, board);
         if (newPos != null) {
             currentPiece = newPos;
             return true;
@@ -95,7 +95,7 @@ public class GameLogic {
     public boolean moveDown() {
         if (gameOver || currentPiece == null) return false;
 
-        TetrominoPosition newPos = SRSRotationSystem.moveDown(currentPiece, board);
+        TetrominoPosition newPos = SuperRotationSystem.moveDown(currentPiece, board);
         if (newPos != null) {
             currentPiece = newPos;
             score += SOFT_DROP_SCORE;
@@ -110,7 +110,7 @@ public class GameLogic {
     public boolean rotateClockwise() {
         if (gameOver || currentPiece == null) return false;
 
-        TetrominoPosition newPos = SRSRotationSystem.attemptRotation(currentPiece, board, true);
+        TetrominoPosition newPos = SuperRotationSystem.attemptRotation(currentPiece, board, true);
         if (newPos != null) {
             currentPiece = newPos;
             return true;
@@ -121,7 +121,7 @@ public class GameLogic {
     public boolean rotateCounterClockwise() {
         if (gameOver || currentPiece == null) return false;
 
-        TetrominoPosition newPos = SRSRotationSystem.attemptRotation(currentPiece, board, false);
+        TetrominoPosition newPos = SuperRotationSystem.attemptRotation(currentPiece, board, false);
         if (newPos != null) {
             currentPiece = newPos;
             return true;
@@ -132,7 +132,7 @@ public class GameLogic {
     public void hardDrop() {
         if (gameOver || currentPiece == null) return;
 
-        TetrominoPosition dropPos = SRSRotationSystem.hardDrop(currentPiece, board);
+        TetrominoPosition dropPos = SuperRotationSystem.hardDrop(currentPiece, board);
         int dropDistance = dropPos.getY() - currentPiece.getY();
         score += dropDistance * HARD_DROP_SCORE;
 

--- a/src/main/java/org/example/game/logic/SuperRotationSystem.java
+++ b/src/main/java/org/example/game/logic/SuperRotationSystem.java
@@ -4,7 +4,7 @@ import org.example.model.GameBoard;
 import org.example.model.TetrominoPosition;
 import org.example.model.Tetromino;
 
-public class SRSRotationSystem {
+public class SuperRotationSystem {
     // SRS Wall Kick Data - kicks for J,L,S,T,Z pieces
     private static final int[][][] JLSTZ_KICKS = {
         // 0->R (0->1)

--- a/src/main/java/org/example/game/state/GameOverState.java
+++ b/src/main/java/org/example/game/state/GameOverState.java
@@ -12,7 +12,6 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 
 public class GameOverState extends GameState {
-    private Scene scene;
     private int finalScore;
     private int finalLines;
     private int finalLevel;
@@ -35,6 +34,11 @@ public class GameOverState extends GameState {
     @Override
     public void exit() {
         // Cleanup if needed
+    }
+
+    @Override
+    public void resume() {
+        // Not applicable for game over state
     }
 
     @Override

--- a/src/main/java/org/example/game/state/GameOverState.java
+++ b/src/main/java/org/example/game/state/GameOverState.java
@@ -1,5 +1,7 @@
 package org.example.game.state;
 
+import org.example.ui.NavigableButtonSystem;
+
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -42,11 +44,6 @@ public class GameOverState extends GameState {
     }
 
     @Override
-    public void update(double deltaTime) {
-        // Game over state doesn't need updates
-    }
-
-    @Override
     public Scene createScene() {
         VBox root = new VBox(25);
         root.setAlignment(Pos.CENTER);
@@ -68,27 +65,11 @@ public class GameOverState extends GameState {
         levelText.setFill(Color.LIGHTGRAY);
         levelText.setFont(Font.font("Arial", 20));
 
-        Button playAgainButton = new Button("Play Again (ENTER)");
-        playAgainButton.setPrefSize(220, 50);
-        playAgainButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        playAgainButton.setOnAction(e -> {
-            // Create new game and go to play state
-            stateManager.setState("play");
-        });
+        NavigableButtonSystem buttonSystem = new NavigableButtonSystem();
 
-        Button mainMenuButton = new Button("Main Menu (ESC)");
-        mainMenuButton.setPrefSize(220, 50);
-        mainMenuButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        mainMenuButton.setOnAction(e -> stateManager.setState("start"));
-
-        Button exitButton = new Button("Exit Game (Q)");
-        exitButton.setPrefSize(220, 50);
-        exitButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        exitButton.setOnAction(e -> System.exit(0));
-
-        Text instructions = new Text("Press ENTER to play again\nPress ESC for main menu\nPress Q to exit");
-        instructions.setFill(Color.LIGHTGRAY);
-        instructions.setFont(Font.font("Arial", 14));
+        var playAgainButton = buttonSystem.createNavigableButton("Play Again", () -> stateManager.setState("play"));
+        var mainMenuButton = buttonSystem.createNavigableButton("Main Menu", () -> stateManager.setState("start"));
+        var exitButton = buttonSystem.createNavigableButton("Exit Game", () -> System.exit(0));
 
         root.getChildren().addAll(
                 title,
@@ -97,31 +78,18 @@ public class GameOverState extends GameState {
                 levelText,
                 playAgainButton,
                 mainMenuButton,
-                exitButton,
-                instructions
+                exitButton
         );
 
-        scene = new Scene(root, 800, 600);
+        scene = new Scene(root, 1000, 700);
 
         // Handle keyboard input
-        scene.setOnKeyPressed(event -> {
-            switch (event.getCode()) {
-                case ENTER, SPACE -> stateManager.setState("play");
-                case ESCAPE -> stateManager.setState("start");
-                case Q -> System.exit(0);
-                default -> {}
-            }
-        });
+        scene.setOnKeyPressed(event -> buttonSystem.handleInput(event));
 
         // Focus for keyboard input
         scene.getRoot().setFocusTraversable(true);
         scene.getRoot().requestFocus();
 
         return scene;
-    }
-
-    @Override
-    public void handleInput() {
-        // Input handled in scene key events
     }
 }

--- a/src/main/java/org/example/game/state/GameState.java
+++ b/src/main/java/org/example/game/state/GameState.java
@@ -1,5 +1,7 @@
 package org.example.game.state;
 
+import org.example.ui.NavigableButtonSystem;
+
 import javafx.scene.Scene;
 
 public abstract class GameState {
@@ -12,8 +14,6 @@ public abstract class GameState {
 
     public abstract void enter();
     public abstract void exit();
-    public abstract void update(double deltaTime);
     public abstract Scene createScene();
-    public abstract void handleInput();
     public abstract void resume();
 }

--- a/src/main/java/org/example/game/state/GameState.java
+++ b/src/main/java/org/example/game/state/GameState.java
@@ -4,6 +4,7 @@ import javafx.scene.Scene;
 
 public abstract class GameState {
     protected GameStateManager stateManager;
+    protected Scene scene;
 
     public GameState(GameStateManager stateManager) {
         this.stateManager = stateManager;
@@ -14,4 +15,5 @@ public abstract class GameState {
     public abstract void update(double deltaTime);
     public abstract Scene createScene();
     public abstract void handleInput();
+    public abstract void resume();
 }

--- a/src/main/java/org/example/game/state/GameStateManager.java
+++ b/src/main/java/org/example/game/state/GameStateManager.java
@@ -41,7 +41,6 @@ public class GameStateManager {
         if (newState == null) {
             throw new IllegalArgumentException("State not found: " + stateName);
         }
-
         if (currentState != null) {
             currentState.exit();
             stateStack.push(currentState);
@@ -58,10 +57,11 @@ public class GameStateManager {
         if (newState == null) {
             throw new IllegalArgumentException("State not found: " + stateName);
         }
-
         if (currentState != null) {
             currentState.exit();
         }
+        stateStack.clear();
+
         newState.enter(); 
         //반드시 enter를 먼저 호출하고 currentState를 변경 해야함.
         //그렇지 않으면 이전 state가 뭔지 잃어버려서 enter할 때 문제가 생김

--- a/src/main/java/org/example/game/state/PauseState.java
+++ b/src/main/java/org/example/game/state/PauseState.java
@@ -12,8 +12,6 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 
 public class PauseState extends GameState {
-    private Scene scene;
-
     public PauseState(GameStateManager stateManager) {
         super(stateManager);
     }
@@ -26,6 +24,11 @@ public class PauseState extends GameState {
     @Override
     public void exit() {
         // Cleanup if needed
+    }
+
+    @Override
+    public void resume() {
+        // 설정창 -> 일시정지 창으로 돌아올 때 사용
     }
 
     @Override
@@ -76,17 +79,8 @@ public class PauseState extends GameState {
         // Handle keyboard input
         scene.setOnKeyPressed(event -> {
             switch (event.getCode()) {
-                case P -> stateManager.setState("play");
-                case R -> {
-                    // Get current play state and reset game
-                    GameState currentPlayState = stateManager.getCurrentState();
-                    if (currentPlayState instanceof PlayState playState) {
-                        if (playState.getGameLogic() != null) {
-                            playState.getGameLogic().reset();
-                        }
-                    }
-                    stateManager.setState("play");
-                }
+                case P -> stateManager.popState();
+                case R -> stateManager.setState("play");
                 case ESCAPE -> stateManager.setState("start");
                 default -> {}
             }

--- a/src/main/java/org/example/game/state/PauseState.java
+++ b/src/main/java/org/example/game/state/PauseState.java
@@ -1,5 +1,7 @@
 package org.example.game.state;
 
+import org.example.ui.NavigableButtonSystem;
+
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -32,11 +34,6 @@ public class PauseState extends GameState {
     }
 
     @Override
-    public void update(double deltaTime) {
-        // Pause state doesn't need updates
-    }
-
-    @Override
     public Scene createScene() {
         VBox root = new VBox(30);
         root.setAlignment(Pos.CENTER);
@@ -46,55 +43,23 @@ public class PauseState extends GameState {
         title.setFill(Color.WHITE);
         title.setFont(Font.font("Arial", 36));
 
-        Button resumeButton = new Button("Resume (P)");
-        resumeButton.setPrefSize(200, 50);
-        resumeButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        resumeButton.setOnAction(e -> stateManager.setState("play"));
+        NavigableButtonSystem buttonSystem = new NavigableButtonSystem();
 
-        Button restartButton = new Button("Restart (R)");
-        restartButton.setPrefSize(200, 50);
-        restartButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        restartButton.setOnAction(e -> {
-            // Reset the game and go to play state
-            PlayState playState = (PlayState) stateManager.getCurrentState();
-            if (playState != null && playState.getGameLogic() != null) {
-                playState.getGameLogic().reset();
-            }
-            stateManager.setState("play");
-        });
+        var resumeButton = buttonSystem.createNavigableButton("Resume", () -> stateManager.popState());
+        var restartButton = buttonSystem.createNavigableButton("Restart", () -> stateManager.setState("play"));
+        var mainMenuButton = buttonSystem.createNavigableButton("Main Menu", () -> stateManager.setState("start"));
 
-        Button mainMenuButton = new Button("Main Menu (ESC)");
-        mainMenuButton.setPrefSize(200, 50);
-        mainMenuButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        mainMenuButton.setOnAction(e -> stateManager.setState("start"));
+        root.getChildren().addAll(title, resumeButton, restartButton, mainMenuButton);
 
-        Text instructions = new Text("Press P to resume\nPress R to restart\nPress ESC for main menu");
-        instructions.setFill(Color.LIGHTGRAY);
-        instructions.setFont(Font.font("Arial", 14));
-
-        root.getChildren().addAll(title, resumeButton, restartButton, mainMenuButton, instructions);
-
-        scene = new Scene(root, 800, 600);
+        scene = new Scene(root, 1000, 700);
 
         // Handle keyboard input
-        scene.setOnKeyPressed(event -> {
-            switch (event.getCode()) {
-                case P -> stateManager.popState();
-                case R -> stateManager.setState("play");
-                case ESCAPE -> stateManager.setState("start");
-                default -> {}
-            }
-        });
+        scene.setOnKeyPressed(event -> buttonSystem.handleInput(event));
 
         // Focus for keyboard input
         scene.getRoot().setFocusTraversable(true);
         scene.getRoot().requestFocus();
 
         return scene;
-    }
-
-    @Override
-    public void handleInput() {
-        // Input handled in scene key events
     }
 }

--- a/src/main/java/org/example/game/state/PlayState.java
+++ b/src/main/java/org/example/game/state/PlayState.java
@@ -10,7 +10,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 import org.example.game.logic.GameLogic;
-import org.example.game.logic.SRSRotationSystem;
+import org.example.game.logic.SuperRotationSystem;
 import org.example.ui.components.HoldPanel;
 import org.example.ui.components.NextPiecePanel;
 import org.example.ui.components.ScorePanel;
@@ -27,7 +27,6 @@ public class PlayState extends GameState {
     private ScorePanel scorePanel;
     private AnimationTimer gameTimer;
     private long lastDropTime;
-    private Scene scene;
     private final Set<KeyCode> pressedKeys = new HashSet<>();
 
     public PlayState(GameStateManager stateManager) {
@@ -56,6 +55,13 @@ public class PlayState extends GameState {
     }
 
     @Override
+    public void resume() {
+        if (gameTimer != null) {
+            gameTimer.start();
+        }
+    }
+
+    @Override
     public void update(double deltaTime) {
         if (gameLogic == null) return;
 
@@ -78,7 +84,7 @@ public class PlayState extends GameState {
         if (gameCanvas != null && gameLogic != null) {
             // Calculate ghost piece position
             var ghostPiece = gameLogic.getCurrentPiece() != null ?
-                    SRSRotationSystem.hardDrop(gameLogic.getCurrentPiece(), gameLogic.getBoard()) : null;
+                    SuperRotationSystem.hardDrop(gameLogic.getCurrentPiece(), gameLogic.getBoard()) : null;
 
             gameCanvas.updateBoard(gameLogic.getBoard(), gameLogic.getCurrentPiece(), ghostPiece);
             holdPanel.updateHoldPiece(gameLogic.getHoldPiece());
@@ -139,7 +145,7 @@ public class PlayState extends GameState {
             case Z -> gameLogic.rotateCounterClockwise();
             case X, UP, W -> gameLogic.rotateClockwise();
             case C -> gameLogic.hold();
-            case P -> stateManager.setState("pause");
+            case P -> stateManager.stackState("pause");
             case ESCAPE -> stateManager.setState("start");
             default -> {}
         }

--- a/src/main/java/org/example/game/state/PlayState.java
+++ b/src/main/java/org/example/game/state/PlayState.java
@@ -61,7 +61,6 @@ public class PlayState extends GameState {
         }
     }
 
-    @Override
     public void update(double deltaTime) {
         if (gameLogic == null) return;
 
@@ -145,15 +144,9 @@ public class PlayState extends GameState {
             case Z -> gameLogic.rotateCounterClockwise();
             case X, UP, W -> gameLogic.rotateClockwise();
             case C -> gameLogic.hold();
-            case P -> stateManager.stackState("pause");
-            case ESCAPE -> stateManager.setState("start");
+            case ESCAPE -> stateManager.stackState("pause");
             default -> {}
         }
-    }
-
-    @Override
-    public void handleInput() {
-        // Input handled in scene key events
     }
 
     public GameLogic getGameLogic() {

--- a/src/main/java/org/example/game/state/StartState.java
+++ b/src/main/java/org/example/game/state/StartState.java
@@ -1,9 +1,10 @@
 package org.example.game.state;
 
+import org.example.ui.NavigableButtonSystem;
+
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.VBox;
@@ -28,12 +29,7 @@ public class StartState extends GameState {
 
     @Override
     public void resume() {
-        
-    }
 
-    @Override
-    public void update(double deltaTime) {
-        // Start state doesn't need updates
     }
 
     @Override
@@ -50,15 +46,9 @@ public class StartState extends GameState {
         subtitle.setFill(Color.LIGHTGRAY);
         subtitle.setFont(Font.font("Arial", 16));
 
-        Button startButton = new Button("Start Game");
-        startButton.setPrefSize(200, 50);
-        startButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        startButton.setOnAction(e -> stateManager.setState("play"));
-
-        Button exitButton = new Button("Exit");
-        exitButton.setPrefSize(200, 50);
-        exitButton.setStyle("-fx-font-size: 18px; -fx-background-color: #4a4a4a; -fx-text-fill: white;");
-        exitButton.setOnAction(e -> System.exit(0));
+        NavigableButtonSystem buttonSystem = new NavigableButtonSystem();
+        var startButton = buttonSystem.createNavigableButton("Start Game", () -> stateManager.setState("play"));
+        var exitButton = buttonSystem.createNavigableButton("Exit", () -> System.exit(0));
 
         Text controls = new Text("Controls:\n" +
                 "← → Move\n" +
@@ -72,22 +62,10 @@ public class StartState extends GameState {
 
         root.getChildren().addAll(title, subtitle, startButton, exitButton, controls);
 
-        scene = new Scene(root, 800, 600);
+        scene = new Scene(root, 1000, 700);
 
-        // Handle keyboard input
-        scene.setOnKeyPressed(event -> {
-            if (event.getCode() == KeyCode.ENTER || event.getCode() == KeyCode.SPACE) {
-                stateManager.setState("play");
-            } else if (event.getCode() == KeyCode.ESCAPE) {
-                System.exit(0);
-            }
-        });
+        scene.setOnKeyPressed(event -> buttonSystem.handleInput(event));
 
         return scene;
-    }
-
-    @Override
-    public void handleInput() {
-        // Input handled in scene key events
     }
 }

--- a/src/main/java/org/example/game/state/StartState.java
+++ b/src/main/java/org/example/game/state/StartState.java
@@ -12,8 +12,6 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 
 public class StartState extends GameState {
-    private Scene scene;
-
     public StartState(GameStateManager stateManager) {
         super(stateManager);
     }
@@ -26,6 +24,11 @@ public class StartState extends GameState {
     @Override
     public void exit() {
         // Cleanup if needed
+    }
+
+    @Override
+    public void resume() {
+        
     }
 
     @Override

--- a/src/main/java/org/example/ui/NavigableButtonSystem.java
+++ b/src/main/java/org/example/ui/NavigableButtonSystem.java
@@ -1,0 +1,90 @@
+package org.example.ui;
+
+import javafx.scene.control.Button;
+import javafx.scene.input.KeyEvent;
+import java.util.ArrayList;
+
+public class NavigableButtonSystem {
+    private ArrayList<Button> buttons;
+    private int selectedButtonIndex = 0;
+
+    public NavigableButtonSystem() {
+        buttons = new ArrayList<>();
+    }
+
+    public void resetSystem() {
+        buttons.clear();
+        selectedButtonIndex = 0;
+    }
+
+    public Button createNavigableButton(String text, Runnable action) {
+        Button button = new Button(text);
+        button.setPrefSize(200, 50);
+        button.setFocusTraversable(false); // 탭 네비게이션 비활성화
+
+        // 마우스 클릭 비활성화 - 클릭 이벤트를 consume하여 무효화
+        button.setOnMouseClicked(event -> event.consume());
+        button.setOnAction(event -> event.consume()); // 액션 이벤트도 무효화
+        button.setUserData(action); // 액션을 버튼의 UserData에 저장
+
+        buttons.add(button);
+        if (buttons.size() == 1) {
+            setSelectedStyle(button);
+        } else {
+            setDefaultStyle(button);
+        }
+
+        return button;
+    }
+
+    private void updateSelectedButton(int newSelectedIndex) {
+        if (newSelectedIndex < 0 || newSelectedIndex >= buttons.size()) {
+            return; // 인덱스 범위 벗어남
+        }
+        setDefaultStyle(buttons.get(selectedButtonIndex));
+        setSelectedStyle(buttons.get(newSelectedIndex));
+        selectedButtonIndex = newSelectedIndex;
+    }
+
+    private void setSelectedStyle(Button button) {
+        button.setStyle("-fx-font-size: 18px; " +
+                "-fx-background-color: #6a6a6a; " +
+                "-fx-text-fill: yellow; " +
+                "-fx-border-color: white; " +
+                "-fx-border-width: 2px; " +
+                "-fx-effect: innershadow(three-pass-box, rgba(0,0,0,0.7), 10, 0, 0, 0);");
+    }
+
+    private void setDefaultStyle(Button button) {
+        button.setStyle("-fx-font-size: 18px; " +
+                "-fx-background-color: #4a4a4a; " +
+                "-fx-text-fill: white;");
+    }
+
+    private void executeSelectedButton() {
+        Button selectedButton = buttons.get(selectedButtonIndex);
+        Runnable action = (Runnable) selectedButton.getUserData();
+        action.run();
+    }
+
+    public void handleInput(KeyEvent event) {
+        int newIdx;
+        switch (event.getCode()) {
+            case UP:
+                newIdx = (selectedButtonIndex - 1 + buttons.size()) % buttons.size();
+                updateSelectedButton(newIdx);
+                break;
+            case DOWN:
+                newIdx = (selectedButtonIndex + 1) % buttons.size();
+                updateSelectedButton(newIdx);
+                break;
+            case ENTER:
+            case SPACE:
+                executeSelectedButton();
+                break;
+            default:
+                // 다른 키들은 무시
+                break;
+        }
+    }
+}

--- a/src/test/java/org/example/game/logic/SuperRotationSystemTest.java
+++ b/src/test/java/org/example/game/logic/SuperRotationSystemTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
-class SRSRotationSystemTest {
+class SuperRotationSystemTest {
 
     private GameBoard gameBoard;
 
@@ -19,7 +19,7 @@ class SRSRotationSystemTest {
     @Test
     void testBasicRotation() {
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 5, 10, 0);
-        TetrominoPosition rotated = SRSRotationSystem.attemptRotation(tPos, gameBoard, true);
+        TetrominoPosition rotated = SuperRotationSystem.attemptRotation(tPos, gameBoard, true);
 
         assertNotNull(rotated);
         assertEquals(1, rotated.getRotation());
@@ -31,7 +31,7 @@ class SRSRotationSystemTest {
     void testWallKick() {
         // Place T piece near right wall where it needs wall kick to rotate
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 8, 10, 0);
-        TetrominoPosition rotated = SRSRotationSystem.attemptRotation(tPos, gameBoard, true);
+        TetrominoPosition rotated = SuperRotationSystem.attemptRotation(tPos, gameBoard, true);
 
         assertNotNull(rotated);
         assertEquals(1, rotated.getRotation());
@@ -43,7 +43,7 @@ class SRSRotationSystemTest {
     void testIPieceWallKick() {
         // Test I piece specific wall kicks
         TetrominoPosition iPos = new TetrominoPosition(Tetromino.I, 7, 10, 0);
-        TetrominoPosition rotated = SRSRotationSystem.attemptRotation(iPos, gameBoard, true);
+        TetrominoPosition rotated = SuperRotationSystem.attemptRotation(iPos, gameBoard, true);
 
         assertNotNull(rotated);
         assertEquals(1, rotated.getRotation());
@@ -53,7 +53,7 @@ class SRSRotationSystemTest {
     void testOPieceRotation() {
         // O piece should always succeed without kicks
         TetrominoPosition oPos = new TetrominoPosition(Tetromino.O, 5, 10, 0);
-        TetrominoPosition rotated = SRSRotationSystem.attemptRotation(oPos, gameBoard, true);
+        TetrominoPosition rotated = SuperRotationSystem.attemptRotation(oPos, gameBoard, true);
 
         assertNotNull(rotated);
         assertEquals(1, rotated.getRotation());
@@ -67,7 +67,7 @@ class SRSRotationSystemTest {
         // Create scenario where rotation is impossible
         fillBoardAroundPosition(5, 10);
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 5, 10, 0);
-        TetrominoPosition rotated = SRSRotationSystem.attemptRotation(tPos, gameBoard, true);
+        TetrominoPosition rotated = SuperRotationSystem.attemptRotation(tPos, gameBoard, true);
 
         assertNull(rotated);
     }
@@ -75,7 +75,7 @@ class SRSRotationSystemTest {
     @Test
     void testCounterClockwiseRotation() {
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 5, 10, 1);
-        TetrominoPosition rotated = SRSRotationSystem.attemptRotation(tPos, gameBoard, false);
+        TetrominoPosition rotated = SuperRotationSystem.attemptRotation(tPos, gameBoard, false);
 
         assertNotNull(rotated);
         assertEquals(0, rotated.getRotation());
@@ -87,7 +87,7 @@ class SRSRotationSystemTest {
         setupTSpinBoard();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 4, 18, 2);
-        SRSRotationSystem.RotationResult result = SRSRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
+        SuperRotationSystem.RotationResult result = SuperRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
 
         assertNotNull(result.getPosition());
         // Should detect T-spin due to wall kick usage and corner blocking
@@ -99,19 +99,19 @@ class SRSRotationSystemTest {
         TetrominoPosition pos = new TetrominoPosition(Tetromino.T, 5, 10, 0);
 
         // Test moveLeft
-        TetrominoPosition left = SRSRotationSystem.moveLeft(pos, gameBoard);
+        TetrominoPosition left = SuperRotationSystem.moveLeft(pos, gameBoard);
         assertNotNull(left);
         assertEquals(4, left.getX());
         assertEquals(10, left.getY());
 
         // Test moveRight
-        TetrominoPosition right = SRSRotationSystem.moveRight(pos, gameBoard);
+        TetrominoPosition right = SuperRotationSystem.moveRight(pos, gameBoard);
         assertNotNull(right);
         assertEquals(6, right.getX());
         assertEquals(10, right.getY());
 
         // Test moveDown
-        TetrominoPosition down = SRSRotationSystem.moveDown(pos, gameBoard);
+        TetrominoPosition down = SuperRotationSystem.moveDown(pos, gameBoard);
         assertNotNull(down);
         assertEquals(5, down.getX());
         assertEquals(11, down.getY());
@@ -120,7 +120,7 @@ class SRSRotationSystemTest {
     @Test
     void testHardDrop() {
         TetrominoPosition pos = new TetrominoPosition(Tetromino.T, 5, 4, 0);
-        TetrominoPosition dropped = SRSRotationSystem.hardDrop(pos, gameBoard);
+        TetrominoPosition dropped = SuperRotationSystem.hardDrop(pos, gameBoard);
 
         assertNotNull(dropped);
         assertEquals(5, dropped.getX());
@@ -131,11 +131,11 @@ class SRSRotationSystemTest {
     void testMovementBlocked() {
         // Test movement blocked by walls
         TetrominoPosition leftWall = new TetrominoPosition(Tetromino.T, 0, 10, 0);
-        TetrominoPosition blocked = SRSRotationSystem.moveLeft(leftWall, gameBoard);
+        TetrominoPosition blocked = SuperRotationSystem.moveLeft(leftWall, gameBoard);
         assertNull(blocked);
 
         TetrominoPosition rightWall = new TetrominoPosition(Tetromino.T, 9, 10, 0);
-        blocked = SRSRotationSystem.moveRight(rightWall, gameBoard);
+        blocked = SuperRotationSystem.moveRight(rightWall, gameBoard);
         assertNull(blocked);
     }
 
@@ -146,7 +146,7 @@ class SRSRotationSystemTest {
 
         for (Tetromino piece : pieces) {
             TetrominoPosition pos = new TetrominoPosition(piece, 5, 10, 0);
-            TetrominoPosition rotated = SRSRotationSystem.attemptRotation(pos, gameBoard, true);
+            TetrominoPosition rotated = SuperRotationSystem.attemptRotation(pos, gameBoard, true);
 
             assertNotNull(rotated, "Failed to rotate " + piece);
             assertEquals(1, rotated.getRotation());
@@ -158,7 +158,7 @@ class SRSRotationSystemTest {
         TetrominoPosition pos = new TetrominoPosition(Tetromino.T, 5, 10, 0);
 
         for (int i = 0; i < 4; i++) {
-            pos = SRSRotationSystem.attemptRotation(pos, gameBoard, true);
+            pos = SuperRotationSystem.attemptRotation(pos, gameBoard, true);
             assertNotNull(pos);
             assertEquals((i + 1) % 4, pos.getRotation());
         }

--- a/src/test/java/org/example/game/logic/TSpinTest.java
+++ b/src/test/java/org/example/game/logic/TSpinTest.java
@@ -19,7 +19,7 @@ class TSpinTest {
     @Test
     void testRotationResultClass() {
         TetrominoPosition pos = new TetrominoPosition(Tetromino.T, 5, 10, 0);
-        SRSRotationSystem.RotationResult result = new SRSRotationSystem.RotationResult(pos, true, 2);
+        SuperRotationSystem.RotationResult result = new SuperRotationSystem.RotationResult(pos, true, 2);
 
         assertEquals(pos, result.getPosition());
         assertTrue(result.isTSpin());
@@ -29,10 +29,10 @@ class TSpinTest {
     @Test
     void testNonTSpinRotation() {
         TetrominoPosition iPos = new TetrominoPosition(Tetromino.I, 5, 10, 0);
-        assertFalse(SRSRotationSystem.isTSpinRotation(iPos, gameBoard));
+        assertFalse(SuperRotationSystem.isTSpinRotation(iPos, gameBoard));
 
         TetrominoPosition oPos = new TetrominoPosition(Tetromino.O, 5, 10, 0);
-        assertFalse(SRSRotationSystem.isTSpinRotation(oPos, gameBoard));
+        assertFalse(SuperRotationSystem.isTSpinRotation(oPos, gameBoard));
     }
 
     @Test
@@ -41,7 +41,7 @@ class TSpinTest {
         setupTSpinSingleBoard();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 4, 17, 2); // T pointing down
-        SRSRotationSystem.RotationResult result = SRSRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
+        SuperRotationSystem.RotationResult result = SuperRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
 
         assertNotNull(result.getPosition());
         // Test may not always result in T-spin depending on board setup
@@ -54,7 +54,7 @@ class TSpinTest {
         setupTSpinDoubleBoard();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 4, 16, 0); // T pointing up
-        SRSRotationSystem.RotationResult result = SRSRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
+        SuperRotationSystem.RotationResult result = SuperRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
 
         assertNotNull(result.getPosition());
         // Test rotation succeeded
@@ -67,7 +67,7 @@ class TSpinTest {
         setupTSpinTripleBoard();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 7, 15, 0); // T pointing up
-        SRSRotationSystem.RotationResult result = SRSRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
+        SuperRotationSystem.RotationResult result = SuperRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
 
         assertNotNull(result.getPosition());
         // Test rotation succeeded
@@ -80,7 +80,7 @@ class TSpinTest {
         setupInsufficientBlockedCorners();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 5, 18, 0);
-        assertFalse(SRSRotationSystem.isTSpinRotation(tPos, gameBoard));
+        assertFalse(SuperRotationSystem.isTSpinRotation(tPos, gameBoard));
     }
 
     @Test
@@ -89,7 +89,7 @@ class TSpinTest {
         setupNonFrontBlockedCorners();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 5, 18, 0); // T pointing up
-        assertFalse(SRSRotationSystem.isTSpinRotation(tPos, gameBoard));
+        assertFalse(SuperRotationSystem.isTSpinRotation(tPos, gameBoard));
     }
 
     @Test
@@ -98,7 +98,7 @@ class TSpinTest {
         setupTSpinMiniBoard();
 
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 1, 18, 1); // T pointing right
-        SRSRotationSystem.RotationResult result = SRSRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
+        SuperRotationSystem.RotationResult result = SuperRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
 
         // Even mini T-spins should be detected as T-spins
         assertNotNull(result.getPosition());
@@ -119,7 +119,7 @@ class TSpinTest {
         };
 
         for (TetrominoPosition pos : positions) {
-            boolean isTSpin = SRSRotationSystem.isTSpinRotation(pos, gameBoard);
+            boolean isTSpin = SuperRotationSystem.isTSpinRotation(pos, gameBoard);
             // Result depends on the specific board setup
             assertNotNull(isTSpin); // Just verify the method doesn't crash
         }
@@ -129,7 +129,7 @@ class TSpinTest {
     void testRegularRotationNoTSpin() {
         // Empty board - regular rotation should not be T-spin
         TetrominoPosition tPos = new TetrominoPosition(Tetromino.T, 5, 10, 0);
-        SRSRotationSystem.RotationResult result = SRSRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
+        SuperRotationSystem.RotationResult result = SuperRotationSystem.attemptRotationWithTSpinCheck(tPos, gameBoard, true);
 
         assertNotNull(result.getPosition());
         assertFalse(result.isTSpin());


### PR DESCRIPTION
## 주요 수정 사항:
- stack을 사용해 이전 페이지를 저장, 불러오는 방식으로 구현 (관련 함수: stackState, popState)
- GameState 추상 클래스에 resume함수 추가 (이전 상태 재개를 위한 함수)
- 게임 오버 됐을 때 점수가 출력되지 않는 버그 수정 (클로드의 코드 순서 실수)

## 기타 수정 사항:
- SRSRotationSystem 클래스의 이름을 SuperRotationSystem으로 변경
- GameState의 구상 클래스들이 똑같은 private scene 변수를 가지고 있어서 추상 클래스에 protected scene 변수를 만들고, 구상 클래스에 있는 private scene 변수는 제거함

## 발견된 이슈:
- 게임 플레이 화면만 다른 화면과 크기와 비율이 달라 화면 전환시 이질감이 생김 -> 화면 크기 통일 필요
- 하드 드롭 버튼(스페이스바)를 꾹 누르고 있으면, 매우 빠른 속도로 블록들이 떨어져 순식간에 게임오버가 됨. -> 하드 드롭 버튼을 꾹 눌러도 현재 블록만 하드 드롭 되도록 수정 필요